### PR TITLE
Check for install-pkg script before running it

### DIFF
--- a/debian/90debathena-metrics
+++ b/debian/90debathena-metrics
@@ -1,1 +1,1 @@
-DPkg::Pre-Install-Pkgs {"/usr/lib/debathena-metrics/install-pkg || :";};
+DPkg::Pre-Install-Pkgs {"test -x /usr/lib/debathena-metrics/install-pkg && /usr/lib/debathena-metrics/install-pkg || :";};

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+debathena-metrics (1.9) unstable; urgency=low
+
+  * Only run the install-pkg command if it exists (Trac: #544)
+
+ -- Jonathan Reed <jdreed@mit.edu>  Thu, 03 Oct 2013 14:04:20 -0400
+
 debathena-metrics (1.8) unstable; urgency=low
 
   * Add git-buildpackage configuration


### PR DESCRIPTION
In the 90debathena-metrics apt.conf snippet, check that the
Pre-Install-Pkg command actually exists before running it, to
avoid printing an annoying warning message after the package
is removed.  (Trac: #544)
